### PR TITLE
fix_python3_bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/PaddlePaddle/PALM.git
 - Python >= 2.7
 - cuda >= 9.0
 - cudnn >= 7.0
-- PaddlePaddle >= 1.5.0 (请参考[安装指南](http://www.paddlepaddle.org/#quick-start)进行安装)
+- PaddlePaddle >= 1.6 (请参考[安装指南](http://www.paddlepaddle.org/#quick-start)进行安装)
 
 ## 目录结构
 

--- a/backbone/utils/transformer.py
+++ b/backbone/utils/transformer.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from functools import partial
+from functools import reduce
 import numpy as np
 
 import paddle.fluid as fluid


### PR DESCRIPTION
1) backbone/utils/transformer.py中reduce操作在python3中不是默认方法，需要改成from functools import reduce；
2）PALM中使用了ema.update(), 这个方法在1.5版本内paddle.fluid.optimizer.py中没有适配python3，最新的develop版本修复了这个问题，修改了README.md中paddle依赖版本到1.6;